### PR TITLE
Increase the PHP limit to allow for PHP 7.4 [unstable]

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
     "require": {
         "ext-bcmath": "*",
         "ext-mbstring": "*",
-        "php": "7.3.*"
+        "php": "7.3.* || 7.4.*"
     },
     "require-dev": {
         "phpunit/phpunit": "^8",


### PR DESCRIPTION
Hi!

This is a quick change to the composer files to allow PHP 7.4 to be used.
This is for the unstable branch.